### PR TITLE
add encoder to cssnano

### DIFF
--- a/gulpfile.js/lib/encoder.js
+++ b/gulpfile.js/lib/encoder.js
@@ -1,0 +1,17 @@
+module.exports = function (val, num) {
+  var base = 26
+  var characters = 'abcdefghijklmnopqrstuvwxyz'
+  var character = num % base
+  var result = characters[character]
+  var remainder = Math.floor(num / base)
+  if (remainder) {
+    base = 38
+    characters = characters + '0123456789-_'
+    while (remainder) {
+      character = remainder % base
+      remainder = Math.floor(remainder / base)
+      result = result + characters[character]
+    }
+  }
+  return result
+}

--- a/gulpfile.js/tasks/css.js
+++ b/gulpfile.js/tasks/css.js
@@ -12,6 +12,7 @@ var path         = require('path');
 var cssnano      = require('gulp-cssnano');
 var combineMq    = require('gulp-combine-mq');
 var replace      = require('gulp-replace')
+var encoder      = require('../lib/encoder')
 
 var paths = {
   src: path.join(config.root.src, config.tasks.css.src, '/**/main.{' + config.tasks.css.extensions + '}'),
@@ -25,7 +26,7 @@ var cssTask = function () {
     .pipe(sass(config.tasks.css.sass))
     .on('error', handleErrors)
     .pipe(autoprefixer(config.tasks.css.autoprefixer))
-    .pipe(gulpif(global.production, cssnano({autoprefixer: false})))
+    .pipe(gulpif(global.production, cssnano({autoprefixer: false, reduceIdents: {encoder}})))
     .pipe(gulpif(!global.production, sourcemaps.write()))
     .pipe(combineMq({
         beautify: false


### PR DESCRIPTION
Fix for the animations in IE with cssnano.
IE11 ignores casesensitivity in keyframes name so W is the same as w.
More details here: https://github.com/ben-eb/cssnano/issues/317
